### PR TITLE
Add Discord badge to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 <p align="center">
   <a href="https://kiro.dev/powers/">Kiro Power</a> &bull;
   <a href="https://insideout.luthersystems.com">InsideOut</a> &bull;
-  <a href="https://luthersystems.com">Luther Systems</a>
+  <a href="https://luthersystems.com">Luther Systems</a> &bull;
+  <a href="https://insideout.luthersystems.com/discord"><img src="https://img.shields.io/badge/Discord-Join%20Us-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
 ---


### PR DESCRIPTION
## Summary
- Add a Discord shield badge to the top navigation links in README.md
- Links to https://insideout.luthersystems.com/discord

## Test plan
- [ ] Verify badge renders correctly on GitHub

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>