### PR TITLE
Gate onboarding on user input to prevent agent auto-demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ MCP support must be enabled in Kiro:
 
 That's it. No API keys, no local binaries, no additional setup.
 
+### Tool Approval Prompts
+
+Kiro asks for approval before each MCP tool call. InsideOut ships with `autoApprove` configured for its safe, read-only tools, but **Kiro does not currently honor the `autoApprove` field** — this is a [known Kiro bug](https://github.com/kirodotdev/Kiro/issues/4323). Until it's fixed, you'll need to click "Allow" for each tool call the first time it's used in a session.
+
+We've pre-configured `autoApprove` in `mcp.json` so that once Kiro fixes this, the conversational and monitoring tools will auto-approve and only `tfgenerate` and `tfdeploy` (which create or modify real cloud infrastructure) will prompt for confirmation.
+
 ## Quick Start
 
 Once installed, mention anything about infrastructure, cloud, AWS, GCP, Terraform, or deployment in a Kiro chat. The power activates automatically.

--- a/mcp.json
+++ b/mcp.json
@@ -1,7 +1,18 @@
 {
   "mcpServers": {
     "insideout": {
-      "url": "https://app.platform.luthersystemsapp.com/insideout-mcp"
+      "url": "https://app.platform.luthersystemsapp.com/insideout-mcp",
+      "autoApprove": [
+        "help",
+        "convoopen",
+        "convoreply",
+        "convoawait",
+        "convostatus",
+        "tfstatus",
+        "tflogs",
+        "awsinspect",
+        "gcpinspect"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds an explicit "present and wait" gate (new Step 2) after calling `help` — the agent must wait for the user to describe what they want before calling `convoopen`
- Scopes the "always take action" rule to only apply after a session is open, preventing the agent from auto-executing the entire onboarding flow
- Marks internal signals like `[TERRAFORM_READY: true]` as agent-only routing markers that must never be shown to users
- Rewrites workflow examples and phase transitions table with agent-centric language so the agent never tells users to "call" tools directly

Closes #5

## Test plan

- [ ] Install as a local power in Kiro IDE
- [ ] Activate the power and verify the agent calls `help` successfully
- [ ] Verify the agent presents a summary and **waits** for user input (does NOT auto-call `convoopen`)
- [ ] Verify the agent does NOT run through example workflows or demo prompts
- [ ] After user describes requirements, verify normal flow proceeds correctly
- [ ] Verify the agent does NOT display `[TERRAFORM_READY: true]` or other internal markers to the user
- [ ] Verify the agent describes tool actions in natural language (e.g., "I'll start a design session") rather than telling users to "call convoopen"

🤖 Generated with [Claude Code](https://claude.com/claude-code)