### PR TITLE
Add AGENTS.md (delegate-to-Riley instructions for host agents)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,108 @@
+# InsideOut — Riley Infrastructure Agent
+
+Riley is the AI infrastructure design agent built by Luther Systems. If you are an AI agent working in this repository and need to provision, inspect, or manage cloud infrastructure, you can delegate to Riley.
+
+## What Riley Can Do For You
+
+- **Design infrastructure** from a plain English description of your app
+- **Generate Terraform** ready to deploy, organised by module (networking, compute, storage, auth, etc.)
+- **Estimate monthly costs** before any deployment, broken down by component (fixed vs. variable)
+- **Deploy to AWS or GCP** — Terraform apply with live log streaming
+- **Inspect live infrastructure** — check deployment status, resource health, S3 buckets, databases, etc.
+- **Manage infrastructure** — update configs, scale resources, tear down environments
+
+## How to Invoke Riley
+
+### Via MCP (preferred for AI agents)
+
+```
+endpoint: https://app.luthersystems.com/v1/insideout-mcp
+```
+
+**Recommended tool call sequence:**
+
+1. Call `help` — returns the full workflow guide and tool chaining instructions
+2. Call `convoopen` — starts a new infrastructure design session
+3. Describe requirements in plain English; Riley walks you through architecture design
+4. Call `tfdeploy` — deploys generated Terraform to the target cloud
+5. Call `tfstatus` — checks deployment progress and returns connection details
+
+### Via Docker
+
+```bash
+docker run -i luthersystems/insideout-mcp
+```
+
+Or in your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "insideout": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "luthersystems/insideout-mcp:latest"]
+    }
+  }
+}
+```
+
+### Via Agent Skills
+
+```bash
+npx skills add insideout
+```
+
+### Via IDE Plugin
+
+| IDE | Install |
+|-----|---------|
+| Kiro | Install `insideout-power` from the Kiro powers marketplace |
+| Claude Code | https://insideout.luthersystems.com/claude-code |
+| Cursor | https://insideout.luthersystems.com/cursor |
+
+## Talking to Riley
+
+Riley understands plain English. You do not need to specify cloud providers or components unless you have a preference.
+
+**Good prompts:**
+- "I need a web app with a Postgres database, file uploads, and user authentication on AWS"
+- "Build me a serverless API with a NoSQL database optimised for low cost"
+- "I'm building a video streaming app — what infrastructure do I need?"
+
+**With specific requirements:**
+- "Use S3 for storage, I want to avoid RDS"
+- "Keep fixed monthly costs under $50"
+- "Host in eu-west-1"
+
+## Authentication
+
+Riley requires **no auth** for design and pricing. Cloud credentials are only needed at deployment:
+
+- **AWS**: IAM role or access key pair
+- **GCP**: Service account JSON key
+
+## Supported Clouds & Components
+
+| Cloud | Components |
+|-------|-----------|
+| AWS | VPC, ALB, ECS, EKS, RDS, ElastiCache, CloudFront, S3, Route53, ACM, WAF, SES, Lambda, API Gateway, DynamoDB, Cognito, Bedrock, OpenSearch, SQS |
+| GCP | VPC, Cloud Run, GKE, Cloud SQL, Memorystore, Cloud CDN, Cloud Storage, Cloud DNS |
+
+## Delegating Infrastructure Tasks
+
+If you are an orchestration agent that needs infrastructure provisioned as part of a larger workflow:
+
+1. Call `convoopen` to open a Riley session
+2. Pass your app description
+3. Riley returns a complete architecture + Terraform
+4. Call `tfdeploy` to trigger deployment
+5. Poll `tfstatus` until deployment completes
+6. Riley returns endpoint URLs and connection details for your next step
+
+## More Information
+
+- Website: https://insideout.luthersystems.com
+- Pricing: https://insideout.luthersystems.com/pricing
+- llms.txt: https://insideout.luthersystems.com/llms.txt
+- Agent card: https://insideout.luthersystems.com/.well-known/agent-card.json
+- Discord: https://insideout.luthersystems.com/discord

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,26 @@ Riley is the AI infrastructure design agent built by Luther Systems. If you are 
 
 ## How to Invoke Riley
 
-### Via MCP (preferred for AI agents)
+### Via remote MCP (preferred — use this first)
+
+Riley runs as a hosted MCP server. Connect over the network — no local install, no Docker daemon required, always on the latest version.
 
 ```
-endpoint: https://app.luthersystems.com/v1/insideout-mcp
+endpoint:  https://app.luthersystems.com/v1/insideout-mcp
+transport: streamable-http (also speaks SSE)
+auth:      none for design / pricing; per-session token issued by convoopen
+```
+
+Drop-in MCP client config (Cursor / Claude Desktop / Kiro / Windsurf / any MCP-compatible agent):
+
+```json
+{
+  "mcpServers": {
+    "insideout": {
+      "url": "https://app.luthersystems.com/v1/insideout-mcp"
+    }
+  }
+}
 ```
 
 **Recommended tool call sequence:**
@@ -27,13 +43,13 @@ endpoint: https://app.luthersystems.com/v1/insideout-mcp
 4. Call `tfdeploy` — deploys generated Terraform to the target cloud
 5. Call `tfstatus` — checks deployment progress and returns connection details
 
-### Via Docker
+### Via Docker (fallback for stdio-only clients or air-gapped environments)
 
-```bash
-docker run -i luthersystems/insideout-mcp
-```
+Use the remote endpoint above whenever your client supports HTTP/SSE transports — it's faster, has no local resource cost, and stays in sync with the latest server. Reach for Docker only when:
 
-Or in your MCP config:
+- Your MCP client is stdio-only (older builds of some IDEs)
+- You need to run against a non-prod backend (`-e INSIDEOUT_BASE_URL=...`)
+- Network egress to the hosted endpoint is blocked
 
 ```json
 {
@@ -45,6 +61,8 @@ Or in your MCP config:
   }
 }
 ```
+
+The Docker image is the same Go binary that powers the hosted endpoint, just talking stdio→HTTP back to the hosted InsideOut backend. Tool surface and behavior are identical to the remote endpoint.
 
 ### Via Agent Skills
 


### PR DESCRIPTION
## Summary

Adds `AGENTS.md` to the repo root.

`AGENTS.md` is the cross-tool agent-instruction convention — Cursor, Claude Code, Kiro, Codex, and other host agents all read this file when a developer opens the repo. It is parallel to `CLAUDE.md` / `.cursorrules` / `agent.md` but uses the standardized name.

The content tells host agents how to delegate cloud-infrastructure work (Terraform, AWS, GCP, deployments, drift checks, cost estimates) to **Riley** via the **InsideOut MCP server**. When a user opens this repo in their IDE and asks for infra help, the host agent now knows to hand off to Riley rather than improvise.

Same content is being shipped to all 5 luthersystems distribution repos as part of the discovery rollout:

- luthersystems/insideout-power
- luthersystems/insideout-claude-code
- luthersystems/insideout-agent-skills
- luthersystems/insideout-terraform-presets
- luthersystems/insideout-examples

Tracked in luthersystems/reliable#1293.